### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/LittleViewer/WeakSignalFinder/security/code-scanning/1](https://github.com/LittleViewer/WeakSignalFinder/security/code-scanning/1)

To fix this issue, add a `permissions` block to the workflow, either at the root level or at the job level. Since no job in the workflow needs privileged access, the minimal required permission is `contents: read`. This should be set at the workflow root so all jobs inherit it by default. Edit the `.github/workflows/main.yml` workflow and add:

```yaml
permissions:
  contents: read
```

immediately after the workflow name (if present), and before the `on:` or `jobs:` block.

No additional imports, dependencies, or code changes are needed outside the YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
