### PR TITLE
feat: add Telegram public channel support

### DIFF
--- a/libCore/feed_class.py
+++ b/libCore/feed_class.py
@@ -1,6 +1,7 @@
 import libCore.utils_class as utils
 import libCore.log_class as log
 import libCore.config_tool_class as ctC
+import libCore.telegram_class as tgC
 import feedparser
 import json
 import asyncio
@@ -9,14 +10,20 @@ class feed:
 
     def extract_feed_link(self, link):
         dict_feed = {}
+        dict_telegram = {}
         if self.utC_.check_file_exist(link):
             handle = self.utC_.file_open(link)
             content = json.load(handle)
             tick = 0
             for only_one_content in content:
-                dict_feed = self.utC_.order_dict(only_one_content["rss_link"], only_one_content["country"], dict_feed, tick)
+                source_type = only_one_content.get("type", "rss")
+                if source_type == "telegram":
+                    source_link = only_one_content.get("telegram_link", only_one_content.get("rss_link", ""))
+                    dict_telegram = self.utC_.order_dict(source_link, only_one_content["country"], dict_telegram, tick)
+                else:
+                    dict_feed = self.utC_.order_dict(only_one_content["rss_link"], only_one_content["country"], dict_feed, tick)
                 tick += 1
-            return dict_feed                
+            return [dict_feed, dict_telegram]
         else:
             self.utC_.error_with_reason("Bad File Path of RSS Feed", True)
 
@@ -33,8 +40,20 @@ class feed:
             result[one_index] = await asyncio.gather(*task[one_index], return_exceptions=True)
             print(f"RSS Feed in {one_index} is read!")
         return result
-                
-    
+
+    async def parse_telegram(self, dict_telegram):
+        """Asynchronously fetch and parse all Telegram channels"""
+        result = {}
+        for country_key in dict_telegram:
+            tasks = []
+            for channel_url in dict_telegram[country_key]:
+                tasks.append(asyncio.to_thread(self.tgC_.fetch_and_parse, channel_url))
+            channel_results = await asyncio.gather(*tasks, return_exceptions=True)
+            result[country_key] = channel_results
+            print(f"Telegram channels in {country_key} are read!")
+        return result
+
+
     def formated_result(self, parsed_feed_list):
         index_list = list(parsed_feed_list.keys())
         formated_feed_list = {}
@@ -47,16 +66,57 @@ class feed:
                     formated_feed_list[one_key].append([getattr(one_article, "title", ""), getattr(one_article,"description",""), getattr(one_article,"published",""), getattr(one_article,"link","")])
             tick += 1
         return formated_feed_list
-    
+
+    def formated_telegram_result(self, parsed_telegram_list):
+        """Format Telegram results into the same structure as RSS"""
+        formated_list = {}
+        for country_key in parsed_telegram_list:
+            if country_key not in formated_list:
+                formated_list[country_key] = []
+            for channel_messages in parsed_telegram_list[country_key]:
+                if isinstance(channel_messages, Exception):
+                    self.lC_.pipe_log(f"Telegram channel fetch error: {channel_messages}", "WARN", "feed() : formated_telegram_result()")
+                    continue
+                if isinstance(channel_messages, list):
+                    formated_list[country_key].extend(channel_messages)
+        return formated_list
+
+    def merge_sources(self, rss_formatted, telegram_formatted):
+        """Merge RSS and Telegram results into a single dict keyed by country"""
+        merged = dict(rss_formatted)
+        for country_key in telegram_formatted:
+            if country_key in merged:
+                merged[country_key].extend(telegram_formatted[country_key])
+            else:
+                merged[country_key] = telegram_formatted[country_key]
+        return merged
+
     async def pipe_extract_rss(self):
-        dict_feed = self.extract_feed_link(self.utC_.absolute_link(self.ctC_.key_return("path", "extract_feed_Path","class_feed")))
-        parsed_feed_list = await self.parse_rss(dict_feed)
-        formated_feed = self.formated_result(parsed_feed_list)
-        self.lC_.pipe_log(f"All articles were aggregated via Feed RSS","INFO","feed() : pipe_extract_rss()")
-        return formated_feed
+        sources = self.extract_feed_link(self.utC_.absolute_link(self.ctC_.key_return("path", "extract_feed_Path","class_feed")))
+        dict_feed = sources[0]
+        dict_telegram = sources[1]
+
+        all_formatted = {}
+
+        # RSS feeds
+        if dict_feed:
+            parsed_feed_list = await self.parse_rss(dict_feed)
+            all_formatted = self.formated_result(parsed_feed_list)
+
+        # Telegram channels
+        if dict_telegram:
+            parsed_telegram_list = await self.parse_telegram(dict_telegram)
+            telegram_formatted = self.formated_telegram_result(parsed_telegram_list)
+            all_formatted = self.merge_sources(all_formatted, telegram_formatted)
+
+        source_count = f"RSS: {len(dict_feed)} countries" if dict_feed else "RSS: none"
+        tg_count = f"Telegram: {len(dict_telegram)} countries" if dict_telegram else "Telegram: none"
+        self.lC_.pipe_log(f"All articles were aggregated ({source_count}, {tg_count})","INFO","feed() : pipe_extract_rss()")
+        return all_formatted
 
 
     def __init__(self):
         self.utC_ = utils.utils()
         self.lC_ = log.log()
         self.ctC_ = ctC.config_toml_tool()
+        self.tgC_ = tgC.telegram()

--- a/libCore/input/rssFeed.json
+++ b/libCore/input/rssFeed.json
@@ -1,9 +1,17 @@
 [
     {"name_organization" : "exemple",
      "rss_link" : "https://liviewer.tv",
-     "country" : "en"
+     "country" : "en",
+     "type" : "rss"
     },
     {"name_organization" : "exemple",
       "rss_link" :  "https://liviewer.tv",
-      "country" : "fr"}
+      "country" : "fr",
+      "type" : "rss"
+    },
+    {"name_organization" : "exemple_telegram",
+      "telegram_link" : "https://t.me/s/exemple_channel",
+      "country" : "fr",
+      "type" : "telegram"
+    }
 ]

--- a/libCore/telegram_class.py
+++ b/libCore/telegram_class.py
@@ -1,0 +1,96 @@
+import libCore.utils_class as utils
+import libCore.log_class as log
+import libCore.config_tool_class as ctC
+import requests
+import re
+from bs4 import BeautifulSoup
+
+class telegram:
+
+    def extract_channel_name(self, url):
+        """Extract channel name from t.me/s/channelname URL"""
+        match = re.search(r't\.me/s/([a-zA-Z0-9_]+)', url)
+        if match:
+            return match.group(1)
+        match = re.search(r't\.me/([a-zA-Z0-9_]+)', url)
+        if match:
+            return match.group(1)
+        return None
+
+    def fetch_channel_page(self, url):
+        """Fetch public Telegram channel web preview page"""
+        channel_name = self.extract_channel_name(url)
+        if not channel_name:
+            self.lC_.pipe_log(f"Invalid Telegram channel URL: {url}", "ERROR", "telegram() : fetch_channel_page()")
+            return None
+
+        fetch_url = f"https://t.me/s/{channel_name}"
+        headers = {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            "Accept-Language": "en-US,en;q=0.5"
+        }
+
+        try:
+            response = requests.get(fetch_url, headers=headers, timeout=30)
+            response.raise_for_status()
+            return response.text
+        except requests.RequestException as e:
+            self.lC_.pipe_log(f"Failed to fetch Telegram channel {channel_name}: {e}", "ERROR", "telegram() : fetch_channel_page()")
+            return None
+
+    def parse_messages(self, html_content, channel_url):
+        """Parse Telegram messages from the web preview HTML"""
+        if not html_content:
+            return []
+
+        soup = BeautifulSoup(html_content, "html.parser")
+        messages = []
+
+        message_wraps = soup.find_all("div", class_="tgme_widget_message")
+
+        for msg in message_wraps:
+            text_div = msg.find("div", class_="tgme_widget_message_text")
+            if not text_div:
+                continue
+
+            message_text = text_div.get_text(separator=" ", strip=True)
+            if not message_text:
+                continue
+
+            # title: first line or first 120 chars
+            first_line = message_text.split("\n")[0].strip()
+            title = first_line[:120] if len(first_line) > 120 else first_line
+
+            # description: full text
+            description = message_text
+
+            # date
+            published = ""
+            time_tag = msg.find("time", {"datetime": True})
+            if time_tag:
+                published = time_tag.get("datetime", "")
+
+            # link
+            link = ""
+            date_link = msg.find("a", class_="tgme_widget_message_date")
+            if date_link and date_link.get("href"):
+                link = date_link["href"]
+            elif msg.get("data-post"):
+                link = f"https://t.me/{msg['data-post']}"
+
+            messages.append([title, description, published, link])
+
+        return messages
+
+    def fetch_and_parse(self, url):
+        """Fetch a Telegram channel and return parsed messages"""
+        html = self.fetch_channel_page(url)
+        messages = self.parse_messages(html, url)
+        self.lC_.pipe_log(f"Telegram channel {url}: {len(messages)} messages extracted", "INFO", "telegram() : fetch_and_parse()")
+        return messages
+
+    def __init__(self):
+        self.utC_ = utils.utils()
+        self.lC_ = log.log()
+        self.ctC_ = ctC.config_toml_tool()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ matplotlib
 asyncio
 dotenv
 click
+requests
+beautifulsoup4
 spacy==3.8.11
 # model of spacy (to modify according to your needs)
 https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.8.0/en_core_web_md-3.8.0-py3-none-any.whl


### PR DESCRIPTION
## Summary
- Add support for scraping **public Telegram channels** via `t.me/s/channelname` (web preview, no login required)
- New `telegram_class.py` in `libCore/` handles fetching and parsing Telegram HTML (BeautifulSoup)
- Modified `feed_class.py` to handle both RSS and Telegram sources with async fetching
- New `type` field in `rssFeed.json` (`"rss"` or `"telegram"`) — fully backward compatible (defaults to `"rss"`)

## Usage
Add a Telegram channel in `rssFeed.json`:
```json
{
    "name_organization": "My Channel",
    "telegram_link": "https://t.me/s/channelname",
    "country": "fr",
    "type": "telegram"
}
```

## Dependencies added
- `requests` — HTTP fetching for Telegram pages
- `beautifulsoup4` — HTML parsing

## Test plan
- [ ] Run `--engine_run` with mixed RSS + Telegram sources
- [ ] Verify Telegram messages flow through the full NLP pipeline
- [ ] Test with invalid/private channel URLs (graceful error handling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)